### PR TITLE
Create .gitattributes to fix broken APK download.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.apk       binary


### PR DESCRIPTION
APK must be attributed as binary for uncorrupted dowloading from GitHub.